### PR TITLE
Added .editorconfig to help standardise code contributions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 4
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+indent_style = tab
+trim_trailing_whitespace = false
+
+[{package.json}]
+indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,16 +6,12 @@ root = true
 
 
 [*]
-
-# Change these settings to your own preference
-indent_style = space
+indent_style = tab
 indent_size = 4
-
-# We recommend you to keep these unchanged
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
-insert_final_newline = true
+insert_final_newline = false
 
 [*.md]
 indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ node_modules
 
 ### Linux ###
 .*
+!.editorconfig
 !.git*
 !.npmignore
 !.travis.yml

--- a/index.js
+++ b/index.js
@@ -1,25 +1,25 @@
 const db = require('db')({
-    username: "neo4j",
-    password: "admin"
+	username: "neo4j",
+	password: "admin"
 });
 const express = require('express'),
-    path = require('path');
+	path = require('path');
 
 var app = express(),
-    server = app.listen(3000, "0.0.0.0", function() {
-        console.log('Listening on *:3000');
-    });
+	server = app.listen(3000, "0.0.0.0", function() {
+		console.log('Listening on *:3000');
+	});
 
 app.get('/', function(req, res) {
-    res.sendFile(path.join(__dirname, 'public/index.html'));
+	res.sendFile(path.join(__dirname, 'public/index.html'));
 });
 
 app.get('/statement/:statement', function(req, res, next) { // TODO: Send this information back to the index.html file, so the user can execute another statement.
-    db.runStatement(decodeURIComponent(req.params.statement), {}, function(result) {
-        res.send(`<pre>${JSON.stringify(result.records, null, 4).split("\\\"").join("")}</pre>`);
-        next();
-    }, function(err) {
-        next(`Got an error trying to run the statement:\n${err}`);
-        res.send(`<pre>${JSON.stringify(err, null, 4).split("\\\"").join("")}</pre>`);
-    });
+	db.runStatement(decodeURIComponent(req.params.statement), {}, function(result) {
+		res.send(`<pre>${JSON.stringify(result.records, null, 4).split("\\\"").join("")}</pre>`);
+		next();
+	}, function(err) {
+		next(`Got an error trying to run the statement:\n${err}`);
+		res.send(`<pre>${JSON.stringify(err, null, 4).split("\\\"").join("")}</pre>`);
+	});
 });

--- a/node_modules/db/index.js
+++ b/node_modules/db/index.js
@@ -8,28 +8,28 @@ module.exports = DB;
 // DB constructor function
 
 function DB(credentials) {
-    if (!(this instanceof DB)) {
-        return new DB(credentials);
-    }
+	if (!(this instanceof DB)) {
+		return new DB(credentials);
+	}
 
-    this.username = credentials.username;
-    this.password = credentials.password;
-    driver = neo4j.driver("bolt://localhost", neo4j.auth.basic(this.username, this.password));
+	this.username = credentials.username;
+	this.password = credentials.password;
+	driver = neo4j.driver("bolt://localhost", neo4j.auth.basic(this.username, this.password));
 }
 
 DB.prototype.closeDriver = function() {
-    driver.close();
+	driver.close();
 }
 
 // Exports functions
 
 DB.prototype.runStatement = function(statement, params, resolve, reject) {
-    var result;
-    var session = driver.session();
-    session
-        .run(statement, params)
-        .then(function(result) {
-            session.close();
-            resolve(result);
-        }).catch(reject);
+	var result;
+	var session = driver.session();
+	session
+		.run(statement, params)
+		.then(function(result) {
+			session.close();
+			resolve(result);
+		}).catch(reject);
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <script type="text/javascript">
-    function runStatement(statement) {
-        window.location += `statement/${encodeURIComponent(statement)}`
-    }
+	function runStatement(statement) {
+		window.location += `statement/${encodeURIComponent(statement)}`
+	}
 </script>


### PR DESCRIPTION
In response to #9, and seeing as you're asking for Hacktoberfest help, I've added an `.editorconfig` for you to help contributors standardise their code contributions. Support for the standard is built into many IDEs already, and others are supported with the use of plugins. For example, I use WebStorm which supports it out of the box and Sublime Text which requires a plugin: http://editorconfig.org/#download

If, like me, you're really keen to enforce a consistent programming style as well as low-level text formatting, you should consider adding [ESLint](http://eslint.org/) to the project (or opening an issue for someone else to do it 😉 ), which will do this for you, as well as providing useful syntax error-checking.